### PR TITLE
Add session persistence and login loader

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:expense_tracker/presentation/screens/edit_transaction_screen.dar
 import 'package:expense_tracker/presentation/screens/home_screen.dart';
 import 'package:expense_tracker/presentation/screens/login_screens.dart';
 import 'package:expense_tracker/presentation/screens/profile_screen.dart';
+import 'package:expense_tracker/presentation/screens/auth_wrapper.dart';
 import 'package:expense_tracker/presentation/providers/transaction_provider.dart';
 import 'package:expense_tracker/data/repositories/firestore_transaction_repository.dart';
 import 'package:expense_tracker/domain/usecases/add_transaction.dart';
@@ -60,8 +61,8 @@ class ExpenseTrackerApp extends StatelessWidget {
             border: OutlineInputBorder(),
           ),
         ),
-        // Початковий маршрут - екран входу
-        initialRoute: '/login',
+        // Головний віджет визначає екран в залежності від стану сесії
+        home: const AuthWrapper(),
         routes: {
           '/login': (context) => const LoginScreen(),
           '/setup': (context) => const SetupScreen(),

--- a/lib/presentation/screens/auth_wrapper.dart
+++ b/lib/presentation/screens/auth_wrapper.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:provider/provider.dart';
+import '../../presentation/screens/home_screen.dart';
+import '../../presentation/screens/login_screens.dart';
+import '../../presentation/screens/setup_screen.dart';
+import '../providers/transaction_provider.dart';
+
+// Віджет, що перевіряє стан автентифікації користувача
+class AuthWrapper extends StatelessWidget {
+  const AuthWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        // Показуємо індикатор, поки перевіряємо стан користувача
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final user = snapshot.data;
+        if (user == null) {
+          // Якщо користувач не залогінений, показуємо екран входу
+          return const LoginScreen();
+        }
+
+        final provider = Provider.of<TransactionProvider>(context, listen: false);
+        provider.updateUser(user.uid);
+        return FutureBuilder(
+          future: provider.loadData(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              // Завантаження даних користувача
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+            // Якщо баланс ще не встановлено - показуємо екран налаштування
+            if (provider.initialBalance == null) {
+              return const SetupScreen();
+            }
+            // Інакше переходимо на головний екран
+            return const HomeScreen();
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/screens/login_screens.dart
+++ b/lib/presentation/screens/login_screens.dart
@@ -20,6 +20,7 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _isLogin = true;
   bool _obscurePassword = true;
   String? _error;
+  bool _isLoading = false;
 
   @override
   void dispose() {
@@ -47,6 +48,10 @@ class _LoginScreenState extends State<LoginScreen> {
       return;
     }
 
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
     try {
       if (_isLogin) {
         await FirebaseAuth.instance.signInWithEmailAndPassword(
@@ -79,11 +84,17 @@ class _LoginScreenState extends State<LoginScreen> {
       setState(() => _error = message);
     } catch (e) {
       setState(() => _error = 'Невідома помилка: $e');
+    } finally {
+      setState(() => _isLoading = false);
     }
   }
 
   // Авторизація через Google
   Future<void> _signInWithGoogle() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
     try {
       final googleUser = await GoogleSignIn().signIn();
       if (googleUser == null) return;
@@ -107,8 +118,10 @@ class _LoginScreenState extends State<LoginScreen> {
       }
     } catch (e) {
       setState(() {
-        _error = 'Помилка входу через Google: \$e';
+        _error = 'Помилка входу через Google: $e';
       });
+    } finally {
+      setState(() => _isLoading = false);
     }
   }
 
@@ -116,12 +129,14 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFF9F9F9),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+      body: Stack(
+        children: [
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
               const SizedBox(height: 24),
               Text(
                 _isLogin ? 'Вхід до акаунту' : 'Створення акаунту',
@@ -248,7 +263,14 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
-    );
+      if (_isLoading)
+        Container(
+          color: Colors.black45,
+          child: const Center(child: CircularProgressIndicator()),
+        ),
+    ],
+  ),
+);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep user logged in with a new `AuthWrapper`
- check auth state on start in `main.dart`
- display progress indicator while signing in

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456aa38238832eaa8f268db1fa8c7b